### PR TITLE
Added SeleniumTest.java (required for Quickstart doc)

### DIFF
--- a/src/test/java/com/saucelabs/advancedselenium/saucedemo/tests/SeleniumTest.java
+++ b/src/test/java/com/saucelabs/advancedselenium/saucedemo/tests/SeleniumTest.java
@@ -1,0 +1,21 @@
+package com.saucelabs.advancedselenium.saucedemo.tests;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.junit.Test;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+public class SeleniumTest {
+
+    @Test
+    public void openBrowser() {
+        // Let WebDriverManager handle drivers
+        WebDriverManager.chromedriver().setup();
+
+        // Start session (opens browser)
+        RemoteWebDriver driver = new ChromeDriver();
+
+        // Quit session (closes browser)
+        driver.quit();
+    }
+}


### PR DESCRIPTION
@titusfortner @diemol , I've added this test, SeleniumTest.java, for the purpose of our [Quickstart Doc](https://docs.saucelabs.com/web-apps/automated-testing/selenium/quickstart/#step-4-run-test). 

SeleniumTest.java was part of an [earlier version of this repo](https://github.com/saucelabs-training/advanced-selenium/tree/v2.1/src/test/java).